### PR TITLE
Add saved_path dir checker when running at the first time

### DIFF
--- a/train.py
+++ b/train.py
@@ -42,6 +42,10 @@ def train(opt):
         torch.cuda.manual_seed(123)
     else:
         torch.manual_seed(123)
+
+    if not os.path.exists(opt.saved_path):
+        os.mkdir(opt.saved_path)
+
     output_file = open(opt.saved_path + os.sep + "logs.txt", "w")
     output_file.write("Model's parameters: {}".format(vars(opt)))
     training_params = {"batch_size": opt.batch_size,


### PR DESCRIPTION
When running `train.py` at the first time, adding the checker code would avoid such error:
```
FileNotFoundError: [Errno 2] No such file or directory: 'trained_models/logs.txt'
``` 